### PR TITLE
feat: Showing heat calendar 

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "react-date-picker": "^5.3.28",
     "react-datepicker": "^0.39.0",
     "react-dom": "^15.4.1",
+    "react-heat-calendar": "^1.0.3",
     "react-pivot": "^1.18.3",
     "react-stickynode": "^1.2.1"
   }

--- a/src/components/container/App.js
+++ b/src/components/container/App.js
@@ -8,6 +8,7 @@ import DatePickerInputRange from "../project/DatePickerInputRange";
 import LastWeekContainer from "./LastWeekContainer/LastWeekContainer";
 import TotalItemCountContainer from "./TotalItemCountContainer/TotalItemCountContainer";
 import TotalWeekCountContainer from "./TotalWeekCountContainer/TotalWeekCountContainer";
+import HeatCalendarContainer from "./HeatCalendarContainer/HeatCalendarContainer";
 import DomainRankingContainer from "./DomainRankingContainer/DomainRankingContainer";
 import DomainStateContainer from "./DomainStateContainer/DomainStateContainer";
 import TagRankingContainer from "./TagRankingContainer/TagRankingContainer";
@@ -80,6 +81,7 @@ export default class App extends React.Component {
                     <TotalItemCountContainer items={this.state.items}/>
                     <TotalWeekCountContainer weeks={this.state.weeks}/>
                     <LastWeekContainer weeks={this.state.weeks}/>
+                    <HeatCalendarContainer {...this.state}/>
                 </div>
             </div>
             <ul className="nav nav-pills">

--- a/src/components/container/HeatCalendarContainer/HeatCalendarContainer.js
+++ b/src/components/container/HeatCalendarContainer/HeatCalendarContainer.js
@@ -1,0 +1,22 @@
+// MIT © 2017 azu
+"use strict";
+const React = require("react");
+
+import HeatCalendar from "react-heat-calendar";
+
+const STYLE = {
+    fontWeight: "normal",
+    fontSize: "16px"
+}
+
+export default class HeatCalendarContainer extends React.Component {
+    render() {
+        const title = `${this.props.items.length} items in the term`
+        const {beginDate, endDate, items} = this.props
+
+        return <div>
+            <h2 style={STYLE}>{title}</h2>
+            <HeatCalendar data={items} beginDate={beginDate} endDate={endDate}/>
+        </div>
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4072,15 +4072,11 @@ react-datepicker@^0.39.0:
     react-onclickoutside "^5.7.1"
     tether "^1.3.2"
 
-"react-dom@^0.14.0 || <15.4.0":
-  version "15.3.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.3.2.tgz#c46b0aa5380d7b838e7a59c4a7beff2ed315531f"
-
-react-dom@^0.14.7:
+"react-dom@^0.14.0 || <15.4.0", react-dom@^0.14.7:
   version "0.14.8"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-0.14.8.tgz#0f1c547514263f771bd31814a739e5306575069e"
 
-react-dom@^15.4.1:
+react-dom@^15.0.0, react-dom@^15.4.1:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.4.1.tgz#d54c913261aaedb17adc20410d029dcc18a1344a"
   dependencies:
@@ -4100,6 +4096,16 @@ react-flex@2.2.7:
   dependencies:
     object-assign "^4.0.1"
     react-class "^2.0.0"
+
+react-heat-calendar@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/react-heat-calendar/-/react-heat-calendar-1.0.3.tgz#535b87068b1de8c6ed5d4b902fd916515d1583bd"
+  dependencies:
+    lodash.countby "^4.6.0"
+    lodash.sortby "^4.7.0"
+    moment "^2.17.1"
+    react "^15.4.2"
+    react-dom "^15.0.0"
 
 react-inline-block@2.0.0:
   version "2.0.0"
@@ -4163,6 +4169,14 @@ react@>=0.12.2, react@^15.4.1:
 "react@^0.14.0 || <15.4.0":
   version "15.3.2"
   resolved "https://registry.yarnpkg.com/react/-/react-15.3.2.tgz#a7bccd2fee8af126b0317e222c28d1d54528d09e"
+  dependencies:
+    fbjs "^0.8.4"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.0"
+
+react@^15.4.2:
+  version "15.4.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.4.2.tgz#41f7991b26185392ba9bae96c8889e7e018397ef"
   dependencies:
     fbjs "^0.8.4"
     loose-envify "^1.1.0"


### PR DESCRIPTION
Hi there! thanks for the awesome dashboard. I am looking forward the JSer.info articles every week.

I have a bit idea to propose, showing heat calendar for data visuzlization, that is like a Github's contribution calendar.

Like this:
![image](https://cloud.githubusercontent.com/assets/1817802/21759134/4bdf883a-d685-11e6-9912-dd1a4492da8a.png)

Thanks,

---
(拙い英語で伝わらないかもしれませんので、日本語でも併記させていただきます。)
いつもJSer.infoにはお世話になっています、毎週楽しみにしています。

ちょっとした提案なのですが、データ可視化のためにGithubのカレンダーのようなものを表示してはどうでしょうか？「コミット=投稿」と見立てて、投稿数が多い日の色が濃くなる感じです。
